### PR TITLE
Disable date_hierarchy on the admin interface.

### DIFF
--- a/aldryn_news/admin.py
+++ b/aldryn_news/admin.py
@@ -13,7 +13,6 @@ from hvad.admin import TranslatableAdmin
 
 class NewsAdmin(FrontendEditableAdmin, TranslatableAdmin, PlaceholderAdmin):
 
-    date_hierarchy = 'publication_start'
     list_display = ['__unicode__', 'publication_start', 'publication_end', 'all_translations']
     form = NewsForm
     frontend_editable_fields = ('title', 'lead_in')


### PR DESCRIPTION
date_hierarchy requires aggregation query operators, which are not available
with the current version of object translation package `hvad`.

This fixes a bug where the admin interface for the news addon errors and is unusable.
