### PR TITLE
Hide the datetime field from ArchiveIndexView; Also bump version.

### DIFF
--- a/aldryn_news/__init__.py
+++ b/aldryn_news/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.1.16'
+__version__ = '0.1.17'
 request_news_identifier = 'aldryn_news_current_news'

--- a/aldryn_news/views.py
+++ b/aldryn_news/views.py
@@ -31,6 +31,16 @@ class ArchiveView(BaseNewsView, ArchiveIndexView):
     template_name = 'aldryn_news/news_list.html'
     date_list_period = 'month'
 
+    @property
+    def uses_datetime_field(self):
+        """Return False.
+
+        This is a nasty, nasty workaround for a problem where HVAD doesn't
+        provide the date field on the translated model, which is the one
+        being queried. Elsewhere, HVAD patches the code to do the right thing
+        but not here."""
+        return False
+
     def get_queryset(self):
         qs = super(ArchiveView, self).get_queryset()
         if 'month' in self.kwargs:


### PR DESCRIPTION
This is a nasty hack to work around HVAD.