### PR TITLE
add url namespace for "reverse" and "url" template tag

### DIFF
--- a/aldryn_news/cms_app.py
+++ b/aldryn_news/cms_app.py
@@ -10,6 +10,7 @@ from cms.apphook_pool import apphook_pool
 class NewsApp(CMSApp):
     name = _('News')
     urls = ['aldryn_news.urls']
+    app_name = 'aldryn_news'
     menus = [NewsCategoryMenu]
 
 apphook_pool.register(NewsApp)

--- a/aldryn_news/models.py
+++ b/aldryn_news/models.py
@@ -86,7 +86,7 @@ class Category(TranslatableModel):
                     return '/'
 
             kwargs = {'category_slug': slug}
-            return reverse('news-category', kwargs=kwargs)
+            return reverse('aldryn_news:news-category', kwargs=kwargs)
 
 
 class Tag(TranslatableModel):
@@ -193,7 +193,7 @@ class News(TranslatableModel):
             if category_slug:
                 kwargs['category_slug'] = category_slug
 
-            return reverse('news-detail', kwargs=kwargs)
+            return reverse('aldryn_news:news-detail', kwargs=kwargs)
 
 
 class LatestNewsPlugin(CMSPlugin):

--- a/aldryn_news/templates/aldryn_news/news_detail.html
+++ b/aldryn_news/templates/aldryn_news/news_detail.html
@@ -8,6 +8,6 @@
 	{% if news.key_visual_id %}<p class="mews-visual"><img src="{% thumbnail news.key_visual 700x200 crop %}" alt="" /></p>{% endif %}
 	<div class="news-lead">{{ news.lead_in|safe }}</div>
 	<div class="news-content">{% render_placeholder news.content %}</div>
-	<p class="news-back"><a href="{% url 'latest-news' %}">{% trans "Back" %}</a></p>
+	<p class="news-back"><a href="{% url 'aldryn_news:latest-news' %}">{% trans "Back" %}</a></p>
 </div>
 {% endblock %}

--- a/aldryn_news/templates/aldryn_news/news_list.html
+++ b/aldryn_news/templates/aldryn_news/news_list.html
@@ -10,7 +10,7 @@
 		{% trans "News" %}{% endif %}</h2>{% endblock %}
 	{% include "aldryn_news/includes/news_items.html" with news=object_list image="true" %}
 	{% if author or archive_date or tagged_entries %}
-	<p class="news-back"><a href="{% url 'latest-news' %}">{% trans "Back" %}</a></p>
+	<p class="news-back"><a href="{% url 'aldryn_news:latest-news' %}">{% trans "Back" %}</a></p>
 	{% endif %}
 {{ tagged_pks }}
 </div>

--- a/aldryn_news/templates/aldryn_news/plugins/archive.html
+++ b/aldryn_news/templates/aldryn_news/plugins/archive.html
@@ -6,11 +6,11 @@
 	<ul class="news-archive">
 		{% for year in years %}
 		<li{% if year.grouper == current_year %} class="active"{% endif %}>
-			<a href="{% url 'archive-year' year=year.grouper %}">{{ year.grouper }}</a>
+			<a href="{% url 'aldryn_news:archive-year' year=year.grouper %}">{{ year.grouper }}</a>
 			<ul>
 				{% for month in year.list %}
 				<li{% if year.grouper == current_year and month.date.month == current_month %} class="active"{% endif %}>
-					<a href="{% url 'archive-month' year=year.grouper month=month.date|date:"n" %}">{{ month.date|date:"F" }} <span>({{ month.count }})</span></a>
+					<a href="{% url 'aldryn_news:archive-month' year=year.grouper month=month.date|date:"n" %}">{{ month.date|date:"F" }} <span>({{ month.count }})</span></a>
 				</li>
 				{% endfor %}
 			</ul>

--- a/aldryn_news/templates/aldryn_news/plugins/tags.html
+++ b/aldryn_news/templates/aldryn_news/plugins/tags.html
@@ -3,7 +3,7 @@
 <div class="plugin plugin-news">
 	<ul class="news-tags">
 		{% for tag in tags %}
-		<li><a href="{% url 'tagged-news' tag=tag.slug %}" class="news-tag-1">{{ tag.name }} <span>({{ tag.count }})</span></a></li>
+		<li><a href="{% url 'aldryn_news:tagged-news' tag=tag.slug %}" class="news-tag-1">{{ tag.name }} <span>({{ tag.count }})</span></a></li>
 		{% empty %}
 		<li class="news-empty"><p>{% trans "No entry found." %}</p></li>
 		{% endfor %}


### PR DESCRIPTION
When have both aldryn_blog and aldryn_news installed, news-detail and latest-news url reverse look up failed, throwing NoReverseMatch exception. This commit added app name and prepend namespace to places that do the url look up.
